### PR TITLE
fixing the race condition happening when vt_close() (which frees vt) …

### DIFF
--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -1425,7 +1425,6 @@ static void *con_thread(void *arg)
                 break;
         }
     }
-    vt_close(con->vt);
     return 0;
 }
 /* open console --------------------------------------------------------------*/
@@ -1457,6 +1456,7 @@ static void con_close(con_t *con)
     if (!con) return;
     con->state=con->vt->state=0;
     pthread_join(con->thread,NULL);
+    vt_close(con->vt);
     free(con);
 }
 /* open socket for remote console --------------------------------------------*/


### PR DESCRIPTION
…happens before con_close() which then tries to write vt, breaking malloc internals and crashing the process when next malloc() occurs